### PR TITLE
bpo-20923 : [doc] Explain ConfigParser 'valid section name' and .SEC…

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -29,7 +29,7 @@ can be customized by end users easily.
 .. note::
 
    This library does *not* interpret or write the value-type prefixes used in
-   the Windows Registry extended version of INI syntax.
+   the Windows Registry extended version of INI syntax. 
 
 .. seealso::
 
@@ -266,6 +266,9 @@ in which case the key/value delimiter may also be left
 out.  Values can also span multiple lines, as long as they are indented deeper
 than the first line of the value.  Depending on the parser's mode, blank lines
 may be treated as parts of multiline values or ignored.
+
+By default,  a legal section name can be any string that does not contain '\\n' or ']'.  
+To change this, see :attr:`ConfigParser.SECTCRE`.
 
 Configuration files may include comments, prefixed by specific
 characters (``#`` and ``;`` by default [1]_).  Comments may appear on


### PR DESCRIPTION
…TCRE

Added "By default, a legal section name can be any string that does not contain '\n' or ']'.  To change this, see configparser.SECTCRE." at "Supported INI File Structure".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
